### PR TITLE
Fix some issues when running in parallel

### DIFF
--- a/bin/run-cucumber
+++ b/bin/run-cucumber
@@ -3,6 +3,9 @@
 require 'fileutils'
 require 'optparse'
 
+require_relative '../utils/errors'
+require_relative '../utils/config_helper'
+
 options = {
   profile: 'default',
   number_of_processes: '1',
@@ -28,6 +31,17 @@ end.parse!
 options[:env]             = ARGV[0]
 options[:additional_args] = ARGV[1..].join(' ')
 
+# Check we have enough users for the number of process
+puts 'Checking enough users are available'
+
+config = ConfigHelper.get_config(options[:env])
+
+%w[buyer admin].each do |role|
+  raise MissingCredentialsError, { role:, index: options[:number_of_processes] } unless config.dig('users', role).length >= options[:number_of_processes].to_i
+end
+
+puts 'Enough users found!'
+
 # Clean the reports directory
 FileUtils.rm_rf 'reports'
 FileUtils.mkdir_p 'reports'
@@ -42,7 +56,23 @@ cucumber_command = if options[:number_of_processes] == '1'
 result = system("CUCUMBER_FORMAT=#{options[:cucumber_format]} TEST_ENV=#{options[:env]} bundle exec #{cucumber_command}")
 
 # Re run tests if we get any failures
-system("CUCUMBER_FORMAT=#{options[:cucumber_format]} TEST_ENV=#{options[:env]} bundle exec cucumber -p rerun") unless result
+unless result
+  # Clean up rerun file
+  rerun_file = 'reports/rerun.txt'
+
+  new_rerun_content = File.readlines(rerun_file).map do |line|
+    line.scan(/(?::\d+features)/).map { |match_data| [match_data, "#{match_data[..-9]}\n#{match_data[-8..]}"] }.each do |find_arg, replace_arg|
+      line.gsub!(find_arg, replace_arg)
+    end
+
+    line
+  end.join
+
+  File.write(rerun_file, new_rerun_content)
+
+  # Re run the failed tests
+  system("CUCUMBER_FORMAT=#{options[:cucumber_format]} TEST_ENV=#{options[:env]} bundle exec cucumber -p rerun")
+end
 
 # Build the report
 system("bundle exec report_builder -s 'reports' -o 'reports/index' -f html -T 'Functional Test Results - #{options[:profile].capitalize}'")

--- a/config/environment.example.yml
+++ b/config/environment.example.yml
@@ -1,31 +1,11 @@
 ---
 users:
   admin:
-    facilities_management:
-      email:
-      password:
-    management_consultancy:
-      email:
-      password:
-    legal_services:
-      email:
-      password:
-    supply_teachers:
-      email:
+    - email:
       password:
   buyer:
-    facilities_management:
-      email:
+    - email:
       password:
-    management_consultancy:
-      email:
-      password:
-    legal_services:
-      email:
-      password:
-    supply_teachers:
-      email:
-      password:
-    no_details:
-      email:
+  no_details:
+    - email:
       password:

--- a/config/environment.test.yml
+++ b/config/environment.test.yml
@@ -1,11 +1,11 @@
 ---
 users:
-  buyer:
-    email: test@example.com
-    password: Password12345!
-  buyer_no_details:
-    email: test_no_buyer_details@example.com
-    password: Password12345!
   admin:
-    email: test_admin@example.com
-    password: Password12345!
+    - email: test_admin@example.com
+      password: Password12345!
+  buyer:
+    - email: test@example.com
+      password: Password12345!
+  no_details:
+    - email: test_no_buyer_details@example.com
+      password: Password12345!

--- a/features/helpers/current_user.rb
+++ b/features/helpers/current_user.rb
@@ -1,15 +1,14 @@
 class CurrentUser
   attr_reader :email, :password
 
-  def initialize(role, service)
+  def initialize(role)
     formatted_role = role.upcase
-    formatted_service = service.upcase.gsub(' ', '_')
 
-    @email = ENV.fetch("#{formatted_role}_EMAIL_#{formatted_service}")
-    @password = ENV.fetch("#{formatted_role}_PASSWORD_#{formatted_service}")
+    @email = ENV.fetch("#{formatted_role}_EMAIL")
+    @password = ENV.fetch("#{formatted_role}_PASSWORD")
   end
 end
 
-def current_user(service, role = 'buyer')
-  @current_user ||= CurrentUser.new(role, service)
+def current_user(role: 'buyer')
+  @current_user ||= CurrentUser.new(role)
 end

--- a/features/services/facilities_management/rm6232/home/navigation_links/navigation_links_signed_in_no_buyer_details.feature
+++ b/features/services/facilities_management/rm6232/home/navigation_links/navigation_links_signed_in_no_buyer_details.feature
@@ -5,7 +5,7 @@ Feature: Facilities Management - Navigation links when signed in - without buyer
     And I am on the 'Find a facilities management supplier' page
     When I click on 'Start now'
     And I am on the 'Sign in to your account' page
-    Given I am a 'no details' user
+    Given I am a no details user
     Then I sign in
     And I am on the 'Manage your details' page
 

--- a/features/services/facilities_management/rm6232/home/start_pages.feature
+++ b/features/services/facilities_management/rm6232/home/start_pages.feature
@@ -15,7 +15,7 @@ Feature: Facilities Management - Start pages
     And I am on the 'Find a facilities management supplier' page
     When I click on 'Start now'
     And I am on the 'Sign in to your account' page
-    Given I am a 'no details' user
+    Given I am a no details user
     Then I sign in
     And I am on the 'Manage your details' page
 
@@ -24,7 +24,6 @@ Feature: Facilities Management - Start pages
     And I am on the 'Find a facilities management supplier' page
     When I click on 'Start now'
     And I am on the 'Sign in to your account' page
-    Given I am a 'facilities management' user
     Then I sign in
     And I am on the 'Your account' page
 
@@ -34,7 +33,6 @@ Feature: Facilities Management - Start pages
     And I am on the 'Find a facilities management supplier' page
     When I click on 'Start now'
     And I am on the 'Sign in to your account' page
-    Given I am a 'facilities management' user
     Then I sign in
     And I am on the 'Your account' page
     Then the following content should be displayed on the page:

--- a/features/services/legal_services/rm6240/home/start_pages.feature
+++ b/features/services/legal_services/rm6240/home/start_pages.feature
@@ -16,6 +16,5 @@ Feature: Legal Services - Start pages
     Then I am on the 'Find legal services for the wider public sector' page
     When I click on 'Start now'
     Then I am on the 'Sign in to your legal services account' page
-    Given I am a 'legal services' user
     Then I sign in
     Then I am on the 'Do you work for central government?' page

--- a/features/services/management_consultancy/rm6187/home/start_pages.feature
+++ b/features/services/management_consultancy/rm6187/home/start_pages.feature
@@ -16,6 +16,5 @@ Feature: Management Consultancy - Start pages
     Then I am on the 'Find management consultants' page
     When I click on 'Start now'
     Then I am on the 'Sign in to your management consultancy account' page
-    Given I am a 'management consultancy' user
     Then I sign in
     Then I am on the 'Select the lot you need' page

--- a/features/services/supply_teachers/rm6238/home/start_pages.feature
+++ b/features/services/supply_teachers/rm6238/home/start_pages.feature
@@ -17,7 +17,6 @@ Feature: Supply Teachers - Start pages
     When I click on 'Start now'
     Then I am on the 'Sign in to find supply teachers and agency workers' page
     Then I click on 'Sign in with CCS'
-    Given I am a 'supply teachers' user
     Then I sign in
     Then I am on the 'What is your school looking for?' page
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -15,7 +15,6 @@ SERVICE_TO_ADMIN_PAGE_TITLE = {
 Given('I sign in and navigate to the start page for the {string} framework in {string}') do |framework, service|
   visit "/#{service.gsub(' ', '-')}/#{framework}/sign-in"
   update_banner_cookie(true)
-  current_user(service)
   step 'I sign in'
   step "I am on the '#{SERVICE_TO_START_PAGE_TITLE.fetch(service)}' page"
 end
@@ -27,14 +26,14 @@ end
 Given('I sign in as an admin for the {string} framework in {string}') do |framework, service|
   visit "/#{service.gsub(' ', '-')}/#{framework}/admin/sign-in"
   update_banner_cookie(true)
-  current_user(service, 'admin')
+  current_user(role: 'admin')
 
   step 'I sign in'
   step "I am on the '#{SERVICE_TO_ADMIN_PAGE_TITLE.fetch(service)}' page"
 end
 
-Then('I am a {string} user') do |service|
-  current_user(service)
+Then('I am a no details user') do
+  current_user(role: 'no_details')
 end
 
 When('I go to {string}') do |uri|
@@ -56,8 +55,8 @@ When('I click on {string}') do |button_text|
 end
 
 Then('I sign in') do
-  fill_in 'Email address', with: @current_user.email
-  fill_in 'Password', with: @current_user.password
+  fill_in 'Email address', with: current_user.email
+  fill_in 'Password', with: current_user.password
   click_button 'Sign in'
 end
 

--- a/features/step_definitions/facilities_management_steps.rb
+++ b/features/step_definitions/facilities_management_steps.rb
@@ -1,7 +1,7 @@
 Given('I sign in and navigate to the start page for the {string} framework in {string} without details') do |framework, service|
   visit "/#{service.gsub(' ', '-')}/#{framework}/sign-in"
   update_banner_cookie(true)
-  step "I am a 'no details' user"
+  step 'I am a no details user'
   step 'I sign in'
   step "I am on the 'Manage your details' page"
 end

--- a/utils/config_helper.rb
+++ b/utils/config_helper.rb
@@ -1,0 +1,14 @@
+require 'yaml'
+require_relative 'errors'
+
+module ConfigHelper
+  class << self
+    def get_config(env)
+      config_filename = "config/environment.#{env}.yml"
+
+      raise MissingConfigFileError, config_filename unless File.file?(config_filename)
+
+      YAML.load_file('config/environment.shared.yml')[env].merge(YAML.load_file("config/environment.#{env}.yml"))
+    end
+  end
+end

--- a/utils/errors.rb
+++ b/utils/errors.rb
@@ -1,0 +1,2 @@
+require_relative 'errors/missing_config_file_error'
+require_relative 'errors/missing_credentials_error'

--- a/utils/errors/missing_config_file_error.rb
+++ b/utils/errors/missing_config_file_error.rb
@@ -1,0 +1,5 @@
+class MissingConfigFileError < StandardError
+  def initialize(missing_file_name)
+    super("Could not find config file with name: '#{missing_file_name}'")
+  end
+end

--- a/utils/errors/missing_credentials_error.rb
+++ b/utils/errors/missing_credentials_error.rb
@@ -1,0 +1,5 @@
+class MissingCredentialsError < StandardError
+  def initialize(error_details)
+    super("Could not find credentials for '#{error_details[:role]}' at index #{error_details[:index]}")
+  end
+end


### PR DESCRIPTION
I released that having a specific user for each service does not work as when we run in parallel the features for the same service could run on different processes but use different emails. Instead, I’ve changed it so that each process should have its own user which means there should not be any conflict.

Another issue is with the rerun file. When the errors are written in, they do not start on a new line for each process which makes the file unreadable. Therefore, I added some code to reformat and fix the file before the rerun task is started.